### PR TITLE
ci: add Windows build support to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,17 @@ jobs:
     name: Build (${{ matrix.name }})
     runs-on:  ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: Linux
             os: ubuntu-latest
 
           - name: macOS
-            os: macos-13
+            os: macos-latest
+
+          - name: Windows
+            os: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -26,16 +30,68 @@ jobs:
           sudo apt-get install -y pkg-config libfreetype6-dev libcairo2-dev
 
       - name: Install dependencies (macOS)
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-latest'
         run: |
           brew install pkg-config freetype cairo
 
-      - name: Build the tools
-        run: make all
+      - name: Setup MSYS2 (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            make
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-cairo
+            mingw-w64-x86_64-freetype
 
-      - name: Publish build artifacts
+      - name: Build the tools (Linux/macOS)
+        if: matrix.os != 'windows-latest'
+        run: |
+          make clean
+          make all -j
+
+      - name: Build and Package the tools (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: msys2 {0}
+        run: |
+          make clean
+          make all -j
+          make windows-debug
+          
+          # Create Windows distribution with DLLs
+          mkdir -p dist/windows
+          cp obj/*.exe dist/windows/
+          
+          # Copy required DLLs for renderer
+          cp /mingw64/bin/libfreetype-6.dll dist/windows/
+          cp /mingw64/bin/libcairo-2.dll dist/windows/
+          cp /mingw64/bin/libbrotlidec.dll dist/windows/
+          cp /mingw64/bin/libbz2-1.dll dist/windows/
+          
+          # Copy any additional DLLs that might be needed
+          ldd obj/blackbox_render.exe | grep "/mingw64/bin" | awk '{print $3}' | xargs -I {} cp {} dist/windows/ 2>/dev/null || true
+
+      - name: Publish build artifacts (Linux/macOS)
+        if: matrix.os != 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: Blackbox tools artifacts ${{matrix.name}}
-          path: obj/*
+          name: Blackbox tools ${{matrix.name}}
+          path: |
+            obj/blackbox_decode
+            obj/blackbox_render
+            obj/encoder_testbed
           retention-days: 60
+          overwrite: true
+
+      - name: Publish build artifacts (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Blackbox tools ${{matrix.name}}
+          path: |
+            dist/windows/
+          retention-days: 60
+          overwrite: true

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,23 @@ SRC_DIR		 = $(ROOT)/src
 OBJECT_DIR	 = $(ROOT)/obj
 BIN_DIR		 = $(ROOT)/obj
 
+# Platform detection
+IS_WINDOWS := $(if $(findstring MINGW,$(shell uname -s)),MINGW,$(if $(findstring MSYS,$(shell uname -s)),MSYS,$(if $(findstring CYGWIN,$(shell uname -s)),CYGWIN,)))
+
+# Package config variables for better maintainability
+CAIRO_CFLAGS    := $(shell pkg-config --cflags cairo)
+CAIRO_LDFLAGS   := $(shell pkg-config --libs cairo)
+FREETYPE_CFLAGS := $(shell pkg-config --cflags freetype2)
+FREETYPE_LDFLAGS:= $(shell pkg-config --libs freetype2)
+
 # Source files common to all targets
 COMMON_SRC	 = parser.c tools.c platform.c stream.c decoders.c units.c blackbox_fielddefs.c
+
+# Platform-specific sources
+ifneq (,$(IS_WINDOWS))
+	COMMON_SRC += lib/getopt_mb_uni/getopt.c
+endif
+
 DECODER_SRC	 = $(COMMON_SRC) blackbox_decode.c gpxwriter.c imu.c battery.c stats.c
 RENDERER_SRC = $(COMMON_SRC) blackbox_render.c datapoints.c embeddedfont.c expo.c imu.c
 ENCODER_TESTBED_SRC = $(COMMON_SRC) encoder_testbed.c encoder_testbed_io.c
@@ -43,6 +58,11 @@ ENCODER_TESTBED_SRC = $(COMMON_SRC) encoder_testbed.c encoder_testbed_io.c
 
 # Search path for baseflight sources
 VPATH		:= $(SRC_DIR)
+
+# Add Windows-specific source paths
+ifneq (,$(IS_WINDOWS))
+	VPATH := $(VPATH):$(ROOT)/lib/getopt_mb_uni
+endif
 
 ###############################################################################
 # Things that might need changing to use different tools
@@ -70,23 +90,38 @@ CFLAGS		= $(ARCH_FLAGS) \
 		$(if $(strip $(BLACKBOX_VERSION)), -DBLACKBOX_VERSION=$(BLACKBOX_VERSION)) \
 		$(DEBUG_FLAGS) \
 		-std=gnu99 \
-		-pthread \
 		-Wall -pedantic -Wextra -Wshadow
 
-CFLAGS += `pkg-config --cflags cairo` `pkg-config --cflags freetype2`
-
-ifeq ($(BUILD_STATIC), MACOSX)
-	# For cairo built with ./configure --enable-quartz=no  --without-x --enable-pdf=no --enable-ps=no --enable-script=no --enable-xcb=no --enable-ft=yes --enable-fc=no --enable-xlib=no
-	LDFLAGS += -Llib/macosx -lcairo -lpixman-1 -lpng16 -lz -lfreetype -lbz2
+# Platform-specific configuration
+ifneq (,$(IS_WINDOWS))
+	# Windows/MINGW build using MSYS2 packages
+	INCLUDE_DIRS += $(ROOT)/lib/getopt_mb_uni
+	
+	# Common Windows libraries for both executables
+	WINDOWS_COMMON_LIBS = -static-libgcc -static-libstdc++ -lole32 -loleaut32 -luuid -lm
+	
+	# Graphics libraries only needed for renderer - try static first, fallback to dynamic
+	WINDOWS_GRAPHICS_LIBS = $(shell pkg-config --libs --static cairo freetype2 2>/dev/null || pkg-config --libs cairo freetype2)
+	WINDOWS_GRAPHICS_LIBS += -lgdi32 -lmsimg32
+	
+	# Renderer-specific CFLAGS (include graphics headers only for renderer)
+	RENDERER_CFLAGS = $(CFLAGS) $(CAIRO_CFLAGS) $(FREETYPE_CFLAGS)
 else
-	# Dynamic linking
-	LDFLAGS += `pkg-config --libs cairo` `pkg-config --libs freetype2`
+	# Unix-like systems (Linux, macOS)
+	CFLAGS += -pthread
+	
+	# Renderer-specific CFLAGS (include graphics headers only for renderer)
+	RENDERER_CFLAGS = $(CFLAGS) $(CAIRO_CFLAGS) $(FREETYPE_CFLAGS)
+	ifeq ($(BUILD_STATIC), MACOSX)
+		# For cairo built with ./configure --enable-quartz=no  --without-x --enable-pdf=no --enable-ps=no --enable-script=no --enable-xcb=no --enable-ft=yes --enable-fc=no --enable-xlib=no
+		RENDERER_LDFLAGS = -Llib/macosx -lcairo -lpixman-1 -lpng16 -lz -lfreetype -lbz2 -lm -pthread
+	else
+		# Dynamic linking
+		RENDERER_LDFLAGS = $(CAIRO_LDFLAGS) $(FREETYPE_LDFLAGS) -lm -pthread
+	endif
+	# Base LDFLAGS for decoder and encoder (no graphics libraries)
+	LDFLAGS += -lm -pthread
 endif
-
-LDFLAGS += -lm
-
-# Required with GCC. Clang warns when using flag while linking, so you can comment this line out if you're using clang:
-LDFLAGS += -pthread
 
 
 ###############################################################################
@@ -109,16 +144,69 @@ TARGET_MAP   = $(OBJECT_DIR)/blackbox_decode.map
 
 all : $(DECODER_ELF) $(RENDERER_ELF) $(ENCODER_TESTBED_ELF)
 
+# Windows-specific linking rules to separate decoder from renderer dependencies
+ifneq (,$(IS_WINDOWS))
+$(DECODER_ELF):  $(DECODER_OBJS)
+	@echo "=== LINKING DECODER (minimal dependencies) ==="
+	@echo "Input objects: $^"
+	@echo "Output: $@"
+	@echo "Command: $(CC) -o $@ $^ $(WINDOWS_COMMON_LIBS)"
+	$(CC) -o $@ $^ $(WINDOWS_COMMON_LIBS)
+	@echo "✅ DECODER LINKING COMPLETE (size: $$(stat -c%s $@ 2>/dev/null || echo 'unknown') bytes)"
+	@echo ""
+
+$(RENDERER_ELF):  $(RENDERER_OBJS)
+	@echo "=== LINKING RENDERER (with graphics libraries) ==="
+	@echo "Input objects: $^"
+	@echo "Output: $@"
+	@echo "Command: $(CC) -o $@ $^ $(WINDOWS_COMMON_LIBS) $(WINDOWS_GRAPHICS_LIBS)"
+	$(CC) -o $@ $^ $(WINDOWS_COMMON_LIBS) $(WINDOWS_GRAPHICS_LIBS)
+	@echo "✅ RENDERER LINKING COMPLETE (size: $$(stat -c%s $@ 2>/dev/null || echo 'unknown') bytes)"
+	@echo ""
+
+$(ENCODER_TESTBED_ELF): $(ENCODER_TESTBED_OBJS)
+	@echo "=== LINKING ENCODER TESTBED (minimal dependencies) ==="
+	@echo "Input objects: $^"
+	@echo "Output: $@"
+	@echo "Command: $(CC) -o $@ $^ $(WINDOWS_COMMON_LIBS)"
+	$(CC) -o $@ $^ $(WINDOWS_COMMON_LIBS)
+	@echo "✅ ENCODER TESTBED LINKING COMPLETE (size: $$(stat -c%s $@ 2>/dev/null || echo 'unknown') bytes)"
+	@echo ""
+else
+# Unix/Linux/macOS - use appropriate LDFLAGS for each target
 $(DECODER_ELF):  $(DECODER_OBJS)
 	@$(CC) -o $@ $^ $(LDFLAGS)
 
 $(RENDERER_ELF):  $(RENDERER_OBJS)
-	@$(CC) -o $@ $^ $(LDFLAGS)
+	@$(CC) -o $@ $^ $(RENDERER_LDFLAGS)
 
 $(ENCODER_TESTBED_ELF): $(ENCODER_TESTBED_OBJS)
 	@$(CC) -o $@ $^ $(LDFLAGS)
+endif
 
-# Compile
+# Compile - separate rules for renderer files vs. other files
+# Renderer-specific files that need graphics headers
+$(OBJECT_DIR)/blackbox_render.o: blackbox_render.c
+	@mkdir -p $(dir $@)
+	@echo %% $(notdir $<) [with graphics headers]
+	@$(CC) -c -o $@ $(RENDERER_CFLAGS) $<
+
+$(OBJECT_DIR)/datapoints.o: datapoints.c
+	@mkdir -p $(dir $@)
+	@echo %% $(notdir $<) [with graphics headers]
+	@$(CC) -c -o $@ $(RENDERER_CFLAGS) $<
+
+$(OBJECT_DIR)/embeddedfont.o: embeddedfont.c
+	@mkdir -p $(dir $@)
+	@echo %% $(notdir $<) [with graphics headers]
+	@$(CC) -c -o $@ $(RENDERER_CFLAGS) $<
+
+$(OBJECT_DIR)/expo.o: expo.c
+	@mkdir -p $(dir $@)
+	@echo %% $(notdir $<) [with graphics headers]
+	@$(CC) -c -o $@ $(RENDERER_CFLAGS) $<
+
+# All other files use standard CFLAGS (no graphics headers)
 $(OBJECT_DIR)/%.o: %.c
 	@mkdir -p $(dir $@)
 	@echo %% $(notdir $<)
@@ -134,3 +222,90 @@ help:
 	@echo "Usage:"
 	@echo "        make [OPTIONS=\"<options>\"]"
 	@echo ""
+	@echo "Targets:"
+	@echo "        all                      # Build all executables (default)"
+	@echo "        clean                    # Clean build artifacts"
+	@echo "        help                     # Show this help"
+	@echo ""
+	@echo "Windows debugging:"
+	@echo "        make windows-pre-debug   # Check build environment before building"
+	@echo "        make windows-debug       # Check executable dependencies after building"
+	@echo "        make windows-collect-dlls # Collect required DLLs for distribution"
+	@echo "        make windows-complete    # Build + debug + collect DLLs if needed"
+	@echo ""
+	@echo "Recommended Windows workflow:"
+	@echo "        make windows-complete    # One-stop solution for Windows builds"
+	@echo ""
+	@echo "Debug targets:"
+	@echo "        debug-platform           # Check platform detection"
+	@echo ""
+
+# Debug platform detection (always available)
+debug-platform:
+	@echo "=== Platform Detection Debug ==="
+	@echo "uname -s: '$(shell uname -s)'"
+	@echo "IS_WINDOWS: '$(IS_WINDOWS)'"
+	@echo "Platform is Windows: $(if $(IS_WINDOWS),YES,NO)"
+	@echo "Available Windows targets: $(if $(IS_WINDOWS),windows-debug windows-pre-debug windows-collect-dlls windows-complete,NONE - not Windows)"
+
+# Enhanced Windows diagnostic target
+ifneq (,$(IS_WINDOWS))
+windows-debug: $(DECODER_ELF) $(RENDERER_ELF)
+	@echo "=== WINDOWS BUILD DEBUG ==="
+	@echo "Build completed successfully"
+	@echo "Checking executable dependencies..."
+	@ls -la $(DECODER_ELF) $(RENDERER_ELF) 2>/dev/null || echo "Executables not found"
+	@echo "=== Dependency Check ==="
+	@ldd $(DECODER_ELF) 2>/dev/null || echo "Decoder: No ldd available or static"
+	@ldd $(RENDERER_ELF) 2>/dev/null || echo "Renderer: No ldd available or static"
+	@echo "=== Debug Complete ==="
+
+# Add a pre-build diagnostic target
+windows-pre-debug:
+	@echo "=== Pre-Build Windows Environment Check ==="
+	@echo "System: $(shell uname -a)"
+	@echo "uname -s output: '$(shell uname -s)'"
+	@echo "IS_WINDOWS value: '$(IS_WINDOWS)'"
+	@echo "Platform detected as Windows: $(if $(IS_WINDOWS),YES,NO)"
+	@echo "Compiler version: $(shell $(CC) --version | head -1)"
+	@echo "Make version: $(shell make --version | head -1)"
+	@echo ""
+	@echo "=== Package Availability ==="
+	@echo "Cairo available: $(shell pkg-config --exists cairo && echo 'YES' || echo 'NO')"
+	@echo "FreeType available: $(shell pkg-config --exists freetype2 && echo 'YES' || echo 'NO')"
+	@echo "Cairo cflags: $(shell pkg-config --cflags cairo 2>/dev/null || echo 'FAILED')"
+	@echo "FreeType cflags: $(shell pkg-config --cflags freetype2 2>/dev/null || echo 'FAILED')"
+	@echo ""
+endif
+
+# Collect required DLLs for distribution if static linking fails
+windows-collect-dlls: $(DECODER_ELF) $(RENDERER_ELF)
+	@echo "=== Collecting Required DLLs for Distribution ==="
+	@mkdir -p dist/windows
+	@cp $(DECODER_ELF) $(RENDERER_ELF) $(ENCODER_TESTBED_ELF) dist/windows/ 2>/dev/null || true
+	@echo "Executables copied to dist/windows/"
+	@echo ""
+	@echo "=== Analyzing DLL Dependencies ==="
+	@echo "Renderer DLL requirements:"
+	@ldd $(RENDERER_ELF) 2>/dev/null | grep -E "(cairo|freetype|pixman|png|harfbuzz|fontconfig)" | while read line; do \
+		dll_path=$$(echo "$$line" | awk '{print $$3}'); \
+		if [ -f "$$dll_path" ]; then \
+			echo "  Copying: $$dll_path"; \
+			cp "$$dll_path" dist/windows/ 2>/dev/null || echo "    ⚠️  Failed to copy $$dll_path"; \
+		fi \
+	done
+	@echo ""
+	@echo "=== Distribution Package Ready ==="
+	@echo "Files in dist/windows:"
+	@ls -la dist/windows/ 2>/dev/null || echo "No files collected"
+
+# Combined target: build, debug, and collect DLLs if needed
+windows-complete: all windows-debug
+	@echo ""
+	@echo "=== Checking if DLL collection is needed ==="
+	@if ldd $(RENDERER_ELF) 2>/dev/null | grep -q "cairo\|freetype"; then \
+		echo "⚠️  External DLLs detected - collecting for distribution"; \
+		$(MAKE) windows-collect-dlls; \
+	else \
+		echo "✅ Static linking successful - no DLL collection needed"; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ ifneq (,$(IS_WINDOWS))
 	# Windows/MINGW build using MSYS2 packages
 	INCLUDE_DIRS += $(ROOT)/lib/getopt_mb_uni
 	
+	# Ensure updated INCLUDE_DIRS is reflected in CFLAGS
+	CFLAGS += $(addprefix -I,$(INCLUDE_DIRS))
+	
 	# Common Windows libraries for both executables
 	WINDOWS_COMMON_LIBS = -static-libgcc -static-libstdc++ -lole32 -loleaut32 -luuid -lm
 	

--- a/Readme.md
+++ b/Readme.md
@@ -180,9 +180,8 @@ make obj/encoder_testbed
 make
 ```
 
-The `blackbox_decode` tool for turning binary flight logs into CSV doesn't depend on any graphics libraries, so can be built by
-running `make obj/blackbox_decode` even if you don't have Cairo or Freetype installed. You can add the resulting `obj/blackbox_decode` program to your system path to
-make it easier to run.
+The `blackbox_decode` tool doesn't depend on any graphics libraries, so it can be built by running `make obj/blackbox_decode` even if you don't have Cairo or Freetype installed.
+You can add the resulting `obj/blackbox_decode` program to your system path to make it easier to run.
 
 The `blackbox_render` tool renders a binary flight log into a series of PNG images which you can overlay on your flight
 video. Please read the section below that most closely matches your operating system for instructions on getting the `libcairo`


### PR DESCRIPTION
- Add windows-latest to build matrix with MSYS2 environment
- Update Makefile to detect Windows/MINGW builds and use precompiled libraries
- Include getopt.c source for Windows builds
- Copy required DLLs to output directory for Windows artifacts
- Use overwrite: true for all artifact uploads
- Properly conditional steps with matrix.os checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows build and packaging support, including tailored build commands and artifact handling.
  * Introduced new Makefile targets for Windows builds, diagnostics, and DLL packaging.

* **Documentation**
  * Expanded and clarified build instructions in the README for Linux, macOS, and Windows, including detailed dependency and troubleshooting guidance.

* **Chores**
  * Updated CI workflow to include Windows as a build target, disabled fail-fast, and switched macOS to the latest version.
  * Modularized and improved platform-specific build logic in the Makefile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->